### PR TITLE
Fix error getting endpoints for storageos-statefulset-sa

### DIFF
--- a/k8s/deploy-storageos/CSI/manifests/030-cluster-roles.yaml
+++ b/k8s/deploy-storageos/CSI/manifests/030-cluster-roles.yaml
@@ -46,7 +46,7 @@ rules:
     resources: ["persistentvolumes"]
     verbs: ["list", "watch", "create", "delete"]
   - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
+    resources: ["persistentvolumeclaims", "endpoints"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]


### PR DESCRIPTION
When using the deploy script, PVC weren't being created due to this error: 
```
I0918 22:37:13.248933       1 leaderelection.go:180] failed to acquire lease storageos/storageos
E0918 22:37:16.210106       1 leaderelection.go:224] error retrieving resource lock storageos/storageos: endpoints "storageos" is forbidden: User "system:serviceaccount:storageos:storageos-statefulset-sa" cannot get endpoints in the namespace "storageos"
I0918 22:37:16.210130       1 leaderelection.go:180] failed to acquire lease storageos/storageos
E0918 22:37:19.423949       1 leaderelection.go:224] error retrieving resource lock storageos/storageos: endpoints "storageos" is forbidden: User "system:serviceaccount:storageos:storageos-statefulset-sa" cannot get endpoints in the namespace "storageos"
```

`storageos-statefulset-sa` is bound to `csi-provisioner-role`, so adding `endpoints` to the resources of `csi-provisioner-role` seemed to be the right place.
