### PR TITLE
Change api version from v1alpha1 to v1

### DIFF
--- a/k8s/deploy-storageos/cluster-operator/manifests/020-crd.yaml
+++ b/k8s/deploy-storageos/cluster-operator/manifests/020-crd.yaml
@@ -12,7 +12,7 @@ spec:
     shortNames:
     - stos
   scope: Namespaced
-  version: v1alpha1
+  version: v1
   additionalPrinterColumns:
   - name: Ready
     type: string
@@ -127,7 +127,7 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
-  version: v1alpha1
+  version: v1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -141,4 +141,4 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
-  version: v1alpha1
+  version: v1

--- a/openshift/deploy-storageos/cluster-operator/manifests/020-crd.yaml
+++ b/openshift/deploy-storageos/cluster-operator/manifests/020-crd.yaml
@@ -12,7 +12,7 @@ spec:
     shortNames:
     - stos
   scope: Namespaced
-  version: v1alpha1
+  version: v1
   additionalPrinterColumns:
   - name: Ready
     type: string
@@ -127,7 +127,7 @@ spec:
     plural: storageosupgrades
     singular: storageosupgrade
   scope: Namespaced
-  version: v1alpha1
+  version: v1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -141,4 +141,4 @@ spec:
     plural: jobs
     singular: job
   scope: Namespaced
-  version: v1alpha1
+  version: v1


### PR DESCRIPTION
- fix issue #37
- change api version from v1alpha1 to v1 for example deployments on
  k8s and OpenShift