### PR TITLE
Set ETCD_ENV to line up with new envvars

### DIFF
--- a/k8s/deploy-storageos/etcd-as-svc/etcd-deployment/etcd-cluster-config.yaml
+++ b/k8s/deploy-storageos/etcd-as-svc/etcd-deployment/etcd-cluster-config.yaml
@@ -4,13 +4,15 @@ metadata:
   name: "storageos-etcd"
 spec:
   size: 3
-  version: "3.3.11"
+  version: "3.3.13"
   pod:
     etcdEnv:
     - name: ETCD_QUOTA_BACKEND_BYTES
       value: "8589934592"  # 8 GB 
     - name: ETCD_AUTO_COMPACTION_RETENTION
-      value: "2" # 2 hours
+      value: "100" # Keep 100 revisions
+    - name: ETCD_AUTO_COMPACTION_MODE
+      value: "revision" # Set the revision mode
 #    persistentVolumeClaimSpec:
 #      storageClassName: gp2
 #      accessModes:

--- a/openshift/deploy-storageos/etcd-as-svc/etcd-deployment/etcd-cluster-config.yaml
+++ b/openshift/deploy-storageos/etcd-as-svc/etcd-deployment/etcd-cluster-config.yaml
@@ -4,13 +4,15 @@ metadata:
   name: "storageos-etcd"
 spec:
   size: 3
-  version: "3.3.11"
+  version: "3.3.13"
   pod:
     etcdEnv:
     - name: ETCD_QUOTA_BACKEND_BYTES
       value: "8589934592"  # 8 GB 
     - name: ETCD_AUTO_COMPACTION_RETENTION
-      value: "2" # 2 hours
+      value: "100" # Keep 100 revisions
+    - name: ETCD_AUTO_COMPACTION_MODE
+      value: "revision" # Set the revision mode
 #    persistentVolumeClaimSpec:
 #      storageClassName: gp2
 #      accessModes:


### PR DESCRIPTION
I've bumped the etcd version and changed the envvars to reflect the new ones [here](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md)

We should test whether this results in compaction every 5min which we could do using the Etcd dashboard you created. 