### PR TITLE
Separate this etcd from any existing etcd cluster

### DIFF
--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/tasks/main.yml
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Install new etcd
   shell: |
        cd /tmp/etcd-v{{ etcd_version }}-linux-amd64
-       mv etcd /usr/local/sbin/etcd
+       mv etcd /usr/local/sbin/etcd3
        mv etcdctl /usr/local/sbin/etcdctl
        chmod 755 /usr/local/sbin/etcd /usr/local/sbin/etcdctl
 - template:

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/templates/etcd3.service
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/templates/etcd3.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=etcd
 Documentation=https://github.com/coreos/etcd
-Conflicts=etcd.service
 Conflicts=etcd2.service
 
 [Service]
@@ -11,7 +10,7 @@ RestartSec=5s
 LimitNOFILE=40000
 TimeoutStartSec=0
 
-ExecStart=/usr/local/sbin/etcd --name etcd-{{ hostvars[inventory_hostname]['inventory_hostname'] }} \
+ExecStart=/usr/local/sbin/etcd3 --name etcd-{{ hostvars[inventory_hostname]['inventory_hostname'] }} \
         --data-dir {{ installation_dir }} \
         --quota-backend-bytes {{ etcd_quota_bytes }} \
         --auto-compaction-retention {{  etcd_auto_compaction_retention }} \


### PR DESCRIPTION
We're running this on @Arau's recommendation on the same etcd nodes as our Kubernetes cluster, just using different ports. However, it clashes as it stands and takes the cluster's existing etcd down which breaks api-server.

This change uses a different binary name and removes the conflict with the normal etcd.