### PR TITLE
Added the option to create a CA cert locally

### DIFF
--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/README.md
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/README.md
@@ -35,7 +35,9 @@ WARNING: The default CA for TLS is statically made as an example. IT SHOULD NOT
 BE USED FOR PRODUCTION! You need to create your own CA either with your own
 tools or using the script below.
 
-To create your own CA, run `sudo ansible-playbook create_ca.yaml`
+To create your own CA, run `ansible-playbook create_ca.yaml`
+
+NOTE: The script uses docker locally, make sure it is installed and properly configured.
 
 The CA files will be created in `./roles/tls_cert/files`
 

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/README.md
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/README.md
@@ -31,7 +31,9 @@ The playbook allows you to enable TLS with client authentication and generates
 the certificates for you. You can edit the cfssl configuration by amending the
 json files in  `roles/tls_cert/templates/`
 
-WARNING: The default CA for TLS is statically made as an example. IT SHOULD NOT BE USED FOR PRODUCTION! You need to create your own CA either with your own tools or using the script below.
+WARNING: The default CA for TLS is statically made as an example. IT SHOULD NOT
+BE USED FOR PRODUCTION! You need to create your own CA either with your own
+tools or using the script below.
 
 To create your own CA, run `sudo ansible-playbook create_ca.yaml`
 

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/README.md
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/README.md
@@ -31,6 +31,12 @@ The playbook allows you to enable TLS with client authentication and generates
 the certificates for you. You can edit the cfssl configuration by amending the
 json files in  `roles/tls_cert/templates/`
 
+WARNING: The default CA for TLS is statically made as an example. IT SHOULD NOT BE USED FOR PRODUCTION! You need to create your own CA either with your own tools or using the script below.
+
+To create your own CA, run `sudo ansible-playbook create_ca.yaml`
+
+The CA files will be created in `./roles/tls_cert/files`
+
 ## Run
 
 ```

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/create_ca.yaml
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/create_ca.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create the CA files needed for TLS
+  hosts: 127.0.0.1
+  connection: local
+  tasks:
+    - name: Create CA cert
+      import_role:
+        name: create_ca
+    

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/files/Dockerfile
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/files/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine
+WORKDIR ~/
+COPY ca-csr.json ca-csr.json
+COPY create_ca.sh create_ca.sh
+RUN wget https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64
+RUN mv cfssljson_1.4.1_linux_amd64 cfssljson
+RUN chmod +x cfssljson
+RUN wget https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64
+RUN mv cfssl_1.4.1_linux_amd64 cfssl
+RUN chmod +x cfssl
+RUN chmod +x create_ca.sh
+RUN mkdir host
+CMD ./create_ca.sh && tail -f /dev/null

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/files/create_ca.sh
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/files/create_ca.sh
@@ -1,0 +1,2 @@
+./cfssl gencert -initca ca-csr.json | ./cfssljson -bare ca -
+mv ca* host/

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/tasks/main.yaml
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/tasks/main.yaml
@@ -1,0 +1,24 @@
+- name: Template ca-csr
+  template:
+    src: ca-csr.json.j2
+    dest: ./roles/create_ca/files/ca-csr.json
+
+- name: Build docker image
+  shell: |
+    docker build ./roles/create_ca/files -t create_ca
+
+- name: Run docker container
+  shell: |
+    docker run -ti -d --name ca_creator create_ca
+    sleep 4
+
+- name: Copy ca files
+  shell: |
+    docker cp ca_creator:~/host/ca.pem ./roles/tls_cert/files
+    docker cp ca_creator:~/host/ca-key.pem ./roles/tls_cert/files
+    docker cp ca_creator:~/host/ca.csr ./roles/tls_cert/files
+  
+- name: Cleanup
+  shell: |
+    docker kill ca_creator
+    docker rm ca_creator

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/templates/ca-csr.json.j2
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/create_ca/templates/ca-csr.json.j2
@@ -1,0 +1,16 @@
+{
+  "CN": "{{ tls.ca_common_name }}",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "O": "Etcd",
+      "OU": "Etcd",
+      "L": "London",
+      "ST": "London",
+      "C": "UK"
+    }
+  ]
+}


### PR DESCRIPTION
We currently use a static CA cert to create the TLS certificates. This PR will give us the option to use an local ansible script to create a new CA locally.

Tested locally on my machine.