### PR TITLE
Change repository address to new etcd-io/etcd repo

### DIFF
--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/tasks/main.yml
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name:  Fetch new etcd
   get_url:
-    url: https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-amd64.tar.gz
+    url: https://github.com/etcd-io/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-amd64.tar.gz
     dest: /tmp/
 
 - name: Unarchive new etcd

--- a/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/templates/etcd3.service.j2
+++ b/k8s/deploy-storageos/etcd-helpers/etcd-ansible-systemd/roles/install_etcd/templates/etcd3.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=etcd
-Documentation=https://github.com/coreos/etcd
+Documentation=https://github.com/etcd-io/etcd
 Conflicts=etcd2.service
 
 [Service]


### PR DESCRIPTION
Update repository url to match the new repo name. Fixes #104 