### PR TITLE
Bundle df json example

### DIFF
--- a/k8s/examples/bundle/bundle-info-alpha.yaml
+++ b/k8s/examples/bundle/bundle-info-alpha.yaml
@@ -63,7 +63,18 @@ spec:
         selector:
           - kind=daemonset
           - app=storageos
-        command: ["df", "-h"]
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "
+          #!/bin/bash
+          # Base64 encoded script to avoid yaml marshalling incompatibility.
+          # The script runs a df piped to an AWK script that formats the output as JSON
+
+          echo -n \"IyEvYmluL2Jhc2gKCmRmIC1oUCBcCnwgYXdrICcKICAgIEJFR0lOIHsKICAgICAgcHJpbnRmICJ7IFwiZGlzY2FycmF5XCI6WyJ9CiAgICAgIHsKICAgICAgICBpZigkMT09IkZpbGVzeXN0ZW0iKQogICAgICAgICAgbmV4dDsKICAgICAgICBpZihhKQogICAgICAgICAgcHJpbnRmICIsIjsKICAgICAgICAgIHByaW50ZiAie1wibW91bnRcIjpcIiIkNiJcIixcInNpemVcIjpcIiIkMiJcIixcInVzZWRcIjpcIiIkMyJcIixcImF2YWlsXCI6XCIiJDQiXCIsXCJ1c2UlXCI6XCIiJDUiXCJ9IjsKICAgICAgICAgIGErKzsKICAgICAgfQogICAgRU5EewogICAgICBwcmludCAiXX0iOwogICAgfQonCg==\" \
+          | base64 --decode \
+          | bash
+        "
         timeout: 90s
     - run:
         name: "ps-all-nodes"

--- a/k8s/examples/bundle/bundle-with-execs-storageos-namespace.yaml
+++ b/k8s/examples/bundle/bundle-with-execs-storageos-namespace.yaml
@@ -22,8 +22,7 @@ spec:
     - exec:
         name: "network-checks"
         collectorName: "netcat"
-        image: arau/tools:0.9
-        namespace: storageos
+        namespace: kube-system
         selector:
           - app=tools
         command:

--- a/k8s/examples/bundle/bundle-with-execs-storageos-namespace.yaml
+++ b/k8s/examples/bundle/bundle-with-execs-storageos-namespace.yaml
@@ -61,7 +61,18 @@ spec:
         selector:
           - kind=daemonset
           - app=storageos
-        command: ["df", "-h"]
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "
+          #!/bin/bash
+          # Base64 encoded script to avoid yaml marshalling incompatibility.
+          # The script runs a df piped to an AWK script that formats the output as JSON
+
+          echo -n \"IyEvYmluL2Jhc2gKCmRmIC1oUCBcCnwgYXdrICcKICAgIEJFR0lOIHsKICAgICAgcHJpbnRmICJ7IFwiZGlzY2FycmF5XCI6WyJ9CiAgICAgIHsKICAgICAgICBpZigkMT09IkZpbGVzeXN0ZW0iKQogICAgICAgICAgbmV4dDsKICAgICAgICBpZihhKQogICAgICAgICAgcHJpbnRmICIsIjsKICAgICAgICAgIHByaW50ZiAie1wibW91bnRcIjpcIiIkNiJcIixcInNpemVcIjpcIiIkMiJcIixcInVzZWRcIjpcIiIkMyJcIixcImF2YWlsXCI6XCIiJDQiXCIsXCJ1c2UlXCI6XCIiJDUiXCJ9IjsKICAgICAgICAgIGErKzsKICAgICAgfQogICAgRU5EewogICAgICBwcmludCAiXX0iOwogICAgfQonCg==\" \
+          | base64 --decode \
+          | bash
+        "
         timeout: 90s
     - exec:
         name: "ps-all-nodes"

--- a/k8s/examples/bundle/bundle-with-execs.yaml
+++ b/k8s/examples/bundle/bundle-with-execs.yaml
@@ -61,8 +61,18 @@ spec:
         selector:
           - kind=daemonset
           - app=storageos
-        command: ["df", "-h"]
-        timeout: 90s
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "
+          #!/bin/bash
+          # Base64 encoded script to avoid yaml marshalling incompatibility.
+          # The script runs a df piped to an AWK script that formats the output as JSON
+
+          echo -n \"IyEvYmluL2Jhc2gKCmRmIC1oUCBcCnwgYXdrICcKICAgIEJFR0lOIHsKICAgICAgcHJpbnRmICJ7IFwiZGlzY2FycmF5XCI6WyJ9CiAgICAgIHsKICAgICAgICBpZigkMT09IkZpbGVzeXN0ZW0iKQogICAgICAgICAgbmV4dDsKICAgICAgICBpZihhKQogICAgICAgICAgcHJpbnRmICIsIjsKICAgICAgICAgIHByaW50ZiAie1wibW91bnRcIjpcIiIkNiJcIixcInNpemVcIjpcIiIkMiJcIixcInVzZWRcIjpcIiIkMyJcIixcImF2YWlsXCI6XCIiJDQiXCIsXCJ1c2UlXCI6XCIiJDUiXCJ9IjsKICAgICAgICAgIGErKzsKICAgICAgfQogICAgRU5EewogICAgICBwcmludCAiXX0iOwogICAgfQonCg==\" \
+          | base64 --decode \
+          | bash
+        "
     - exec:
         name: "ps-all-nodes"
         collectorName: "processlist"


### PR DESCRIPTION
For better automation for ingesting data, it is preferable to have the outputs of commands as JSON if possible. 

This change executes an script that runs `df` and pipes to `awk` for formatting the output as JSON.

Because of issues with marshalling yaml while placing scripts and awk instructions it is best to encode with base64.

To review the PR, I would suggest to decode the base64 blob:

```
echo -n "IyEvYmluL2Jhc2gKCmRmIC1oUCBcCnwgYXdrICcKICAgIEJFR0lOIHsKICAgICAgcHJpbnRmICJ7IFwiZGlzY2FycmF5XCI6WyJ9CiAgICAgIHsKICAgICAgICBpZigkMT09IkZpbGVzeXN0ZW0iKQogICAgICAgICAgbmV4dDsKICAgICAgICBpZihhKQogICAgICAgICAgcHJpbnRmICIsIjsKICAgICAgICAgIHByaW50ZiAie1wibW91bnRcIjpcIiIkNiJcIixcInNpemVcIjpcIiIkMiJcIixcInVzZWRcIjpcIiIkMyJcIixcImF2YWlsXCI6XCIiJDQiXCIsXCJ1c2UlXCI6XCIiJDUiXCJ9IjsKICAgICAgICAgIGErKzsKICAgICAgfQogICAgRU5EewogICAgICBwcmludCAiXX0iOwogICAgfQonCg=="  \
          | base64 --decode 

# and you can pipe to | bash to execute the script (just a df)
```